### PR TITLE
Fix #12 - Block only half visible on page

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3,11 +3,11 @@
 }
 
 .block_metalink .felement {
-    width: 65% !important;
+    width: 95% !important;
 }
 
 .block_metalink .fitemtitle {
-    width: 30% !important;
+    width: 40% !important;
 }
 
 .block_metalink .fdescription.required {

--- a/styles.css
+++ b/styles.css
@@ -4,7 +4,6 @@
 
 .block_metalink .felement {
     width: 65% !important;
-    margin-left: 33% !important;
 }
 
 .block_metalink .fitemtitle {


### PR DESCRIPTION
Previous layout:
![metalinks layout](https://cloud.githubusercontent.com/assets/7804636/8104672/79d68036-102a-11e5-8740-ae8c47a7ba0c.PNG)

New layout will look like this:
![new metalink layout](https://cloud.githubusercontent.com/assets/7804636/8104630/35bdc88c-102a-11e5-99bb-8f0226e8f41f.JPG)
